### PR TITLE
Fix #17: ch2 image truncated

### DIFF
--- a/chapter2/Chapter 2.ipynb
+++ b/chapter2/Chapter 2.ipynb
@@ -20,7 +20,9 @@
     "import torch.nn.functional as F\n",
     "import torchvision\n",
     "from torchvision import transforms\n",
-    "from PIL import Image\n"
+    "from PIL import Image, ImageFile\n",
+    "\n",
+    "ImageFile.LOAD_TRUNCATED_IMAGES=True"
    ]
   },
   {


### PR DESCRIPTION
Fix for this error:

```
  File ".../Python/3.7.6/site-packages/PIL/ImageFile.py", line 220, in load
    raise IOError("image file is truncated (%d bytes not processed)" % len(b))
IOError: image file is truncated (57 bytes not processed)
```
Solution from here: https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images