### PR TITLE
Ch6 Add excecution of precompute_spectrograms() and path for train/valid dir

### DIFF
--- a/chapter6/Chapter 6.ipynb
+++ b/chapter6/Chapter 6.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Chapter 6: A Journey Into Sound\nDownload and extract the ESC-50 files from https://github.com/karolpiczak/ESC-50#download"
+    "# Chapter 6: A Journey Into Sound\n",
+    "Download and extract the ESC-50 files from https://github.com/karolpiczak/ESC-50#download"
    ]
   },
   {
@@ -301,7 +302,13 @@
     "        spectrogram = librosa.feature.melspectrogram(audio_tensor, sr=sr)\n",
     "        log_spectrogram = librosa.power_to_db(spectrogram, ref=np.max)\n",
     "        librosa.display.specshow(log_spectrogram, sr=sr, x_axis='time', y_axis='mel')\n",
-    "        plt.gcf().savefig(\"{}{}_{}.png\".format(filename.parent,dpi,filename.name), dpi=dpi)"
+    "        plt.gcf().savefig(\"{}{}_{}.png\".format(filename.parent,dpi,filename.name), dpi=dpi)\n",
+    "\n",
+    "PATH_ESC50_TRAIN = PATH_TO_ESC50 / \"train\"\n",
+    "PATH_ESC50_VALID = PATH_TO_ESC50 / \"valid\"\n",
+    "\n",
+    "precompute_spectrograms(PATH_ESC50_TRAIN)\n",
+    "precompute_spectrograms(PATH_ESC50_VALID)"
    ]
   },
   {


### PR DESCRIPTION
#22 

I added the excecution of precompute_spectrograms() and path for train/valid dir, so that the precomputed spectrograms are saved on disk before being processed by PrecomputedESC50.