### PR TITLE
Ch6 Change self.transforms to self.img_transforms as in Ch2.ipynb

### DIFF
--- a/chapter6/Chapter 6.ipynb
+++ b/chapter6/Chapter 6.ipynb
@@ -15,21 +15,21 @@
    "outputs": [],
    "source": [
     "import IPython.display as display\n",
-    "import torchaudio\n",
-    "from torch.utils.data import Dataset\n",
-    "from pathlib import Path\n",
+    "import librosa\n",
+    "import librosa.display\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import random\n",
     "import torch\n",
+    "import torchaudio\n",
     "import torch.optim as optim\n",
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
-    "from torchvision import models\n",
     "import torchvision\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import librosa\n",
-    "import librosa.display\n",
-    "import random\n",
-    "from PIL import Image\n"
+    "from pathlib import Path\n",
+    "from PIL import Image\n",
+    "from torch.utils.data import Dataset\n",
+    "from torchvision import models, transforms"
    ]
   },
   {
@@ -318,19 +318,19 @@
    "outputs": [],
    "source": [
     "class PrecomputedESC50(Dataset):\n",
-    "    def __init__(self,path,dpi=50, transforms=None):\n",
+    "    def __init__(self,path,dpi=50, img_transforms=None):\n",
     "        files = Path(path).glob('{}{}*.wav.png'.format(path.name, dpi))\n",
     "        self.items = [(f,int(f.name.split(\"-\")[-1].replace(\".wav.png\",\"\"))) for f in files]\n",
     "        self.length = len(self.items)\n",
-    "        if transforms == None:\n",
-    "            self.transforms = torchvision.transforms.Compose([torchvision.transforms.ToTensor()])\n",
+    "        if img_transforms == None:\n",
+    "            self.img_transforms = transforms.Compose([transforms.ToTensor()])\n",
     "        else:\n",
-    "            self.transforms = transforms\n",
+    "            self.img_transforms = img_transforms\n",
     "    \n",
     "    def __getitem__(self, index):\n",
     "        filename, label = self.items[index]\n",
     "        img = Image.open(filename).convert('RGB')\n",
-    "        return (self.transforms(img), label)\n",
+    "        return (self.img_transforms(img), label)\n",
     "            \n",
     "    def __len__(self):\n",
     "        return self.length"
@@ -355,8 +355,8 @@
     "    param.requires_grad = False\n",
     "\n",
     "spec_resnet.fc = nn.Sequential(nn.Linear(spec_resnet.fc.in_features,500),\n",
-    "nn.ReLU(), \n",
-    "nn.Dropout(), nn.Linear(500,50))"
+    "                               nn.ReLU(),\n",
+    "                               nn.Dropout(), nn.Linear(500,50))"
    ]
   },
   {
@@ -365,13 +365,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "esc50pre_train = PrecomputedESC50(PATH_ESC50_TRAIN, transforms=torchvision.transforms.Compose([torchvision.transforms.ToTensor(),\n",
-    "                                                                                torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
-    "                                                                                                                 std=[0.229, 0.224, 0.225])]))\n",
+    "esc50pre_train = PrecomputedESC50(PATH_ESC50_TRAIN,\n",
+    "                                  img_transforms=transforms.Compose([\n",
+    "                                      transforms.ToTensor(),\n",
+    "                                      transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
+    "                                                           std=[0.229, 0.224, 0.225])])\n",
+    ")\n",
     "\n",
-    "esc50pre_valid = PrecomputedESC50(PATH_ESC50_VALID, transforms=torchvision.transforms.Compose([torchvision.transforms.ToTensor(),\n",
-    "                                                                                torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
-    "                                                                                                                 std=[0.229, 0.224, 0.225])]))                                                                                                                  \n",
+    "esc50pre_valid = PrecomputedESC50(PATH_ESC50_VALID,\n",
+    "                                  img_transforms=transforms.Compose([\n",
+    "                                      transforms.ToTensor(),\n",
+    "                                      transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
+    "                                                           std=[0.229, 0.224, 0.225])])\n",
+    ")\n",
+    "\n",
     "esc50_train_loader = torch.utils.data.DataLoader(esc50pre_train, bs, shuffle=True)\n",
     "esc50_val_loader = torch.utils.data.DataLoader(esc50pre_valid, bs, shuffle=True)"
    ]
@@ -493,8 +500,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "torchvision.transforms.Compose([FrequencyMask(max_width=10, use_mean=False),\n",
-    "torchvision.transforms.ToPILImage()])(torch.rand(3,250,200))"
+    "transforms.Compose([FrequencyMask(max_width=10, use_mean=False),\n",
+    "transforms.ToPILImage()])(torch.rand(3,250,200))"
    ]
   },
   {
@@ -548,8 +555,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "torchvision.transforms.Compose([TimeMask(max_width=10, use_mean=False),\n",
-    "torchvision.transforms.ToPILImage()])(torch.rand(3,250,200))"
+    "transforms.Compose([TimeMask(max_width=10, use_mean=False),\n",
+    "transforms.ToPILImage()])(torch.rand(3,250,200))"
    ]
   },
   {
@@ -559,20 +566,23 @@
    "outputs": [],
    "source": [
     "class PrecomputedTransformESC50(Dataset):\n",
-    "    def __init__(self,path,dpi=50):\n",
+    "    def __init__(self, path, max_freqmask_width, max_timemask_width, use_mean=True, dpi=50):\n",
     "        files = Path(path).glob('{}*.wav.png'.format(dpi))\n",
     "        self.items = [(f,f.name.split(\"-\")[-1].replace(\".wav.png\",\"\")) for f in files]\n",
     "        self.length = len(self.items)\n",
-    "        self.transforms = transforms.Compose([\n",
-    "    transforms.ToTensor(),\n",
-    "    RandomApply([FrequencyMask(self.max_freqmask_width)]p=0.5),\n",
-    "    RandomApply([TimeMask(self.max_timemask_width)]p=0.5)\n",
+    "        self.max_freqmask_width = max_freqmask_width\n",
+    "        self.max_timemask_width = max_timemask_width\n",
+    "        self.use_mean = use_mean\n",
+    "        self.img_transforms = transforms.Compose([\n",
+    "            transforms.ToTensor(),\n",
+    "            transforms.RandomApply([FrequencyMask(self.max_freqmask_width, self.use_mean)], p=0.5),\n",
+    "            transforms.RandomApply([TimeMask(self.max_timemask_width, self.use_mean)], p=0.5)\n",
     "])\n",
     "        \n",
     "    def __getitem__(self, index):\n",
     "        filename, label = self.items[index]\n",
     "        img = Image.open(filename)\n",
-    "        return (self.transforms(img), label)\n",
+    "        return (self.img_transforms(img), label)\n",
     "        \n",
     "    def __len__(self):\n",
     "        return self.length"


### PR DESCRIPTION
I had to add some bits to make the rest of file work properly. I made the following changes along, which I think might shorten the code a bit and harmonize it with the preceding notebooks.

- Change self.transforms to self.img_transforms as in Ch2.ipynb,
- shorten torchvision.transforms to transforms as in docstring Mask (Frequency and Time),
- insert attributes to PrecomputedTransformESC50: max_freqmask_width, max_timemask_width, use_mean. (may be still to implement different use_mean attributes for time/frequency?)

