### PR TITLE
Ch2 Change dimension choice for softmax to 1

### DIFF
--- a/chapter2/Chapter 2.ipynb
+++ b/chapter2/Chapter 2.ipynb
@@ -249,7 +249,7 @@
     "            targets = targets.to(device)\n",
     "            loss = loss_fn(output,targets) \n",
     "            valid_loss += loss.data.item() * inputs.size(0)\n",
-    "            correct = torch.eq(torch.max(F.softmax(output, dim=0), dim=1)[1], targets).view(-1)\n",
+    "            correct = torch.eq(torch.max(F.softmax(output, dim=1), dim=1)[1], targets).view(-1)\n",
     "            num_correct += torch.sum(correct).item()\n",
     "            num_examples += correct.shape[0]\n",
     "        valid_loss /= len(val_loader.dataset)\n",
@@ -288,7 +288,7 @@
     "img = img_transforms(img).to(device)\n",
     "\n",
     "\n",
-    "prediction = F.softmax(simplenet(img))\n",
+    "prediction = F.softmax(simplenet(img), dim=1)\n",
     "prediction = prediction.argmax()\n",
     "print(labels[prediction]) "
    ]


### PR DESCRIPTION
#7 

I propose changing the dimension choice for softmax to 1 to ensure the values of both classes after applying softmax sum up to 1.

Explanation:
https://github.com/falloutdurham/beginners-pytorch-deep-learning/commit/df4e02b4d6d1ded1fe6accccea3bd74ba5fc2960#commitcomment-40375203

Also the second change in the softmax argument to dim=1 seems to be important (though if left out, the deprecated version is set to dim=1 automatically) - if you set the dim=0 there, the tensor of size(2) would have both values being equal to 1. and thus the prediction of the class would be taken randomly. See https://stackoverflow.com/questions/55139801/index-selection-in-case-of-conflict-in-pytorch-argmax