### PR TITLE
Ch2 delete .view(-1) after torch.max() in train() function

### DIFF
--- a/chapter2/Chapter 2.ipynb
+++ b/chapter2/Chapter 2.ipynb
@@ -249,7 +249,7 @@
     "            targets = targets.to(device)\n",
     "            loss = loss_fn(output,targets) \n",
     "            valid_loss += loss.data.item() * inputs.size(0)\n",
-    "            correct = torch.eq(torch.max(F.softmax(output, dim=1), dim=1)[1], targets).view(-1)\n",
+    "            correct = torch.eq(torch.max(F.softmax(output, dim=1), dim=1)[1], targets)\n",
     "            num_correct += torch.sum(correct).item()\n",
     "            num_examples += correct.shape[0]\n",
     "        valid_loss /= len(val_loader.dataset)\n",


### PR DESCRIPTION
I think in the line 
`correct = torch.eq(torch.max(F.softmax(output, dim=1), dim=1)[1], targets).view(-1)` 
applying the `.view(-1)` function is not required since `torch.eq(torch.max(F.softmax(output, dim=1), dim=1)[1], targets)` is a 1D tensor and thus applying `view()` does not change the shape of the tensor. Am I wrong or is there another reason for the usage?