### PR TITLE
Ch2: Add torch.unqueeze() in order to add 4th dimension at index 0

### DIFF
--- a/chapter2/Chapter 2.ipynb
+++ b/chapter2/Chapter 2.ipynb
@@ -286,6 +286,7 @@
     "\n",
     "img = Image.open(\"./val/fish/100_1422.JPG\") \n",
     "img = img_transforms(img).to(device)\n",
+    "img = torch.unsqueeze(img, 0)\n",
     "\n",
     "simplenet.eval()\n",
     "prediction = F.softmax(simplenet(img), dim=1)\n",


### PR DESCRIPTION
#52

There was missing the line 

`img = torch.unsqueeze(img, 0)`

in order to add an additional dimension as the model expects a DataLoader object with batches.