### PR TITLE
Ch5 Fix googletrans AttributeError (#57)

### DIFF
--- a/chapter5/Chapter 5.ipynb
+++ b/chapter5/Chapter 5.ipynb
@@ -387,6 +387,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install googletrans version 3.1.0a0 (temporary fix for #57)\n",
+    "!pip install googletrans==3.1.0a0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "import googletrans\n",
     "import random\n",
     "\n",
@@ -411,7 +420,13 @@
     "translations_en_random = translator.translate(t_text, src=tr_lang, dest='en')\n",
     "en_text = [t.text for t in translations_en_random]\n",
     "print(en_text)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",

--- a/chapter5/Chapter 5.ipynb
+++ b/chapter5/Chapter 5.ipynb
@@ -420,13 +420,7 @@
     "translations_en_random = translator.translate(t_text, src=tr_lang, dest='en')\n",
     "en_text = [t.text for t in translations_en_random]\n",
     "print(en_text)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
As mentioned in #57, it's necessary to pip install version `3.1.0a0` of `googletrans` to avoid an AttributeError.